### PR TITLE
Some organization, plus animated lock POC

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -8,10 +8,10 @@ const extend = require('xtend')
 const Toggle = require('react-toggle')
 const actions = require('./actions')
 // init
-const InitializeMenuScreen = require('./init-menu')
-const CreateVaultScreen = require('./create-vault')
-const CreateVaultCompleteScreen = require('./create-vault-complete')
-const RestoreVaultScreen = require('./restore-vault')
+const InitializeMenuScreen = require('./first-time/init-menu')
+const CreateVaultScreen = require('./first-time/create-vault')
+const CreateVaultCompleteScreen = require('./first-time/create-vault-complete')
+const RestoreVaultScreen = require('./first-time/restore-vault')
 // unlock
 const UnlockScreen = require('./unlock')
 // accounts
@@ -41,7 +41,7 @@ App.prototype.render = function() {
   return (
 
     h('.flex-column.flex-grow.full-height', [
-      
+
       // top row
       h('.app-header.flex-column.flex-center', [
         h('h1', 'MetaMask'),
@@ -62,7 +62,7 @@ App.prototype.render = function() {
         // help
         h('i.fa.fa-question.fa-lg.cursor-pointer'),
       ]),
-      
+
     ])
 
   )
@@ -91,10 +91,10 @@ App.prototype.renderPrimary = function(state){
 
       case 'createVault':
         return h(CreateVaultScreen)
-      
+
       case 'restoreVault':
         return h(RestoreVaultScreen)
-      
+
       default:
         return h(InitializeMenuScreen)
 
@@ -112,7 +112,7 @@ App.prototype.renderPrimary = function(state){
 
     case 'createVaultComplete':
       return h(CreateVaultCompleteScreen)
-    
+
     case 'accounts':
       return h(AccountsScreen)
 
@@ -121,7 +121,7 @@ App.prototype.renderPrimary = function(state){
 
     case 'confTx':
       return h(ConfirmTxScreen)
-    
+
     default:
       return h(AccountsScreen)
 
@@ -130,15 +130,36 @@ App.prototype.renderPrimary = function(state){
 }
 
 function onOffToggle(state){
+  var buttonSize = '50px';
+  var lockWidth = '20px';
   return (
-    
-    h('.app-toggle.flex-row.flex-center', [
-      h('label', 'OFF'),
-      h(Toggle, {
-        checked: state.isUnlocked,
-        onChange: state.toggleMetamaskActive,
-      }),
-      h('label', 'ON'),
+    h('.app-toggle.flex-row.flex-center.lock' + (state.isUnlocked ? '.unlocked' : '.locked'), {
+      width: buttonSize,
+      height: buttonSize,
+    }, [
+      h('div', {
+        onClick: state.toggleMetamaskActive,
+        style: {
+          width: lockWidth,
+          height: '' + parseInt(lockWidth) * 1.5 + 'px',
+          position: 'relative',
+        }
+      }, [
+        h('img.lock-top', {
+          src: 'images/lock-top.png',
+          style: {
+            width: lockWidth,
+            position: 'absolute',
+          }
+        }),
+        h('img', {
+          src: 'images/lock-base.png',
+          style: {
+            width: lockWidth,
+            position: 'absolute',
+          }
+        }),
+      ])
     ])
 
   )

--- a/app/app.js
+++ b/app/app.js
@@ -5,7 +5,6 @@ const PropTypes = require('react').PropTypes
 const connect = require('react-redux').connect
 const h = require('react-hyperscript')
 const extend = require('xtend')
-const Toggle = require('react-toggle')
 const actions = require('./actions')
 // init
 const InitializeMenuScreen = require('./first-time/init-menu')

--- a/app/css/index.css
+++ b/app/css/index.css
@@ -145,6 +145,27 @@ app sections
 }
 
 /* unlock */
+.lock {
+  width: 50px;
+  height: 50px;
+}
+
+.lock.locked .lock-top {
+  transform: scaleX(1) translateX(0);
+  transition: transform 300ms ease-in;
+}
+.lock.unlocked .lock-top {
+  transform: scaleX(-1) translateX(-12px);
+  transition: transform 300ms ease-in;
+}
+.lock.unlocked:hover {
+  border-radius: 4px;
+  background: #e5e5e5;
+  border: 1px solid #b1b1b1;
+}
+.lock.unlocked:active {
+  background: #c3c3c3;
+}
 
 .section-title .fa-arrow-left {
   margin: -2px 8px 0px -8px;

--- a/app/css/index.css
+++ b/app/css/index.css
@@ -83,14 +83,6 @@ h2.page-subtitle {
   padding-bottom: 10px;
 }
 
-.app-footer .app-toggle {
-  font-size: 12px;
-}
-
-.app-footer .app-toggle label {
-  margin: 0 8px;
-}
-
 .identicon {
   height: 46px;
   width: 46px;

--- a/app/css/index.css
+++ b/app/css/index.css
@@ -142,13 +142,24 @@ app sections
   height: 50px;
 }
 
+.lock.locked {
+  transform: scale(1.5);
+  opacity: 0.0;
+  transition: opacity 400ms ease-in, transform 400ms ease-in;
+}
+.lock.unlocked {
+  transform: scale(1);
+  opacity: 1;
+  transition: opacity 500ms ease-out, transform 500ms ease-out, background 200ms ease-in;
+}
+
 .lock.locked .lock-top {
   transform: scaleX(1) translateX(0);
-  transition: transform 300ms ease-in;
+  transition: transform 250ms ease-in;
 }
 .lock.unlocked .lock-top {
   transform: scaleX(-1) translateX(-12px);
-  transition: transform 300ms ease-in;
+  transition: transform 250ms ease-in;
 }
 .lock.unlocked:hover {
   border-radius: 4px;

--- a/app/first-time/create-vault-complete.js
+++ b/app/first-time/create-vault-complete.js
@@ -2,7 +2,7 @@ const inherits = require('util').inherits
 const Component = require('react').Component
 const connect = require('react-redux').connect
 const h = require('react-hyperscript')
-const actions = require('./actions')
+const actions = require('../actions')
 
 module.exports = connect(mapStateToProps)(CreateVaultCompleteScreen)
 
@@ -21,7 +21,7 @@ function mapStateToProps(state) {
 CreateVaultCompleteScreen.prototype.render = function() {
   var state = this.props
   return (
-    
+
     h('.initialize-screen.flex-column.flex-center.flex-grow', [
 
       // subtitle and nav
@@ -44,7 +44,7 @@ CreateVaultCompleteScreen.prototype.render = function() {
 
     ])
 
-  ) 
+  )
 }
 
 CreateVaultCompleteScreen.prototype.showAccounts = function() {

--- a/app/first-time/create-vault.js
+++ b/app/first-time/create-vault.js
@@ -2,7 +2,7 @@ const inherits = require('util').inherits
 const Component = require('react').Component
 const connect = require('react-redux').connect
 const h = require('react-hyperscript')
-const actions = require('./actions')
+const actions = require('../actions')
 
 module.exports = connect(mapStateToProps)(CreateVaultScreen)
 
@@ -19,7 +19,7 @@ function mapStateToProps(state) {
 CreateVaultScreen.prototype.render = function() {
   var state = this.props
   return (
-    
+
     h('.initialize-screen.flex-column.flex-center.flex-grow', [
 
       // subtitle and nav
@@ -57,20 +57,20 @@ CreateVaultScreen.prototype.render = function() {
       }, 'OK'),
 
       (!state.inProgress && this.warning) && (
-        
+
         h('span.in-progress-notification', this.warning)
 
       ),
 
       state.inProgress && (
-        
+
         h('span.in-progress-notification', 'Generating Seed...')
 
       ),
 
     ])
 
-  ) 
+  )
 }
 
 CreateVaultScreen.prototype.componentDidMount = function(){

--- a/app/first-time/init-menu.js
+++ b/app/first-time/init-menu.js
@@ -4,11 +4,10 @@ const Component = require('react').Component
 const connect = require('react-redux').connect
 const h = require('react-hyperscript')
 const getCaretCoordinates = require('textarea-caret')
-const Mascot = require('./components/mascot')
-const actions = require('./actions')
+const Mascot = require('../components/mascot')
+const actions = require('../actions')
 
 module.exports = connect(mapStateToProps)(InitializeMenuScreen)
-
 
 inherits(InitializeMenuScreen, Component)
 function InitializeMenuScreen() {
@@ -23,22 +22,20 @@ function mapStateToProps(state) {
   }
 }
 
-
-
 InitializeMenuScreen.prototype.render = function() {
   var state = this.props
 
   switch (state.currentView.name) {
-    
+
     case 'createVault':
       return h(CreateVaultPage)
-    
+
     case 'createVaultComplete':
       return this.renderCreateVaultComplete()
-    
+
     case 'restoreVault':
       return this.renderRestoreVault()
-    
+
     default:
       return this.renderMenu()
 
@@ -53,7 +50,7 @@ InitializeMenuScreen.prototype.render = function() {
 InitializeMenuScreen.prototype.renderMenu = function() {
   var state = this.props
   return (
-    
+
     h('.initialize-screen.flex-column.flex-center.flex-grow', [
 
       h('h2.page-subtitle', 'Welcome!'),
@@ -65,7 +62,7 @@ InitializeMenuScreen.prototype.renderMenu = function() {
       h('button.btn-thin', {
         onClick: this.showCreateVault.bind(this),
       }, 'Create New Vault'),
-      
+
       h('.flex-row.flex-center.flex-grow', [
         h('hr'),
         h('div', 'OR'),
@@ -78,13 +75,13 @@ InitializeMenuScreen.prototype.renderMenu = function() {
 
     ])
 
-  ) 
+  )
 }
 
 InitializeMenuScreen.prototype.renderCreateVault = function() {
   var state = this.props
   return (
-    
+
     h('.initialize-screen.flex-column.flex-center.flex-grow', [
 
       // subtitle and nav
@@ -125,20 +122,20 @@ InitializeMenuScreen.prototype.renderCreateVault = function() {
       }, 'OK'),
 
       this.props.warning && (
-        
+
         h('span', this.props.warning)
 
       ),
 
     ])
 
-  ) 
+  )
 }
 
 InitializeMenuScreen.prototype.renderCreateVaultComplete = function() {
   var state = this.props
   return (
-    
+
     h('.initialize-screen.flex-column.flex-center.flex-grow', [
 
       // subtitle and nav
@@ -161,13 +158,13 @@ InitializeMenuScreen.prototype.renderCreateVaultComplete = function() {
 
     ])
 
-  ) 
+  )
 }
 
 InitializeMenuScreen.prototype.renderRestoreVault = function() {
   var state = this.props
   return (
-    
+
     h('.initialize-screen.flex-column.flex-center.flex-grow', [
 
       // subtitle and nav
@@ -186,7 +183,7 @@ InitializeMenuScreen.prototype.renderRestoreVault = function() {
 
     ])
 
-  ) 
+  )
 }
 
 // InitializeMenuScreen.prototype.splitWor = function() {

--- a/app/first-time/restore-vault.js
+++ b/app/first-time/restore-vault.js
@@ -2,7 +2,7 @@ const inherits = require('util').inherits
 const Component = require('react').Component
 const connect = require('react-redux').connect
 const h = require('react-hyperscript')
-const actions = require('./actions')
+const actions = require('../actions')
 
 module.exports = connect(mapStateToProps)(RestoreVaultScreen)
 
@@ -20,7 +20,7 @@ function mapStateToProps(state) {
 RestoreVaultScreen.prototype.render = function() {
   var state = this.props
   return (
-    
+
     h('.initialize-screen.flex-column.flex-center.flex-grow', [
 
       // subtitle and nav
@@ -39,7 +39,7 @@ RestoreVaultScreen.prototype.render = function() {
 
     ])
 
-  ) 
+  )
 }
 
 RestoreVaultScreen.prototype.showInitializeMenu = function() {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "react-dom": "^0.14.3",
     "react-hyperscript": "^2.2.2",
     "react-redux": "^4.0.3",
-    "react-toggle": "^2.0.1",
     "redux": "^3.0.5",
     "redux-logger": "^2.3.1",
     "redux-thunk": "^1.0.2",


### PR DESCRIPTION
Moved all initial views into a `first-time` folder, to get the `app` folder to start resembling the actual app hierarchy more.

Changed the bottom toggle switch into an animated lock icon.

Used a combination of normal css (for class transitions) and inline React element styles, which lets me use logic and variables on the styles, and keep them inline with the rest of the component.

A lot of the benefits feel lost by having to do both, but I do really like describing an element in one place.  Did it this way partly to start a discussion, and try out what this style might look like.

![metamask-lock-concept](https://cloud.githubusercontent.com/assets/542863/13479543/898bca3a-e08c-11e5-8854-a944eb422789.gif)

@kumavis 
