### PR TITLE
Add simple test to scaffold test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-installation
+## Installation
 
 ```
 git clone git@github.com:MetaMask/metamask-ui.git
@@ -6,3 +6,9 @@ cd metamask-ui
 npm install
 grunt dev
 ```
+
+## Testing
+
+Requires `mocha` installed. Run `npm install -g mocha`.
+
+You can either run the test suite once with `npm test`, or you can reload on file changes, by running `mocha watch test/**/**`.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "mocha test/**/**",
     "start": "beefy example.js:bundle.js --live --open",
     "build": "browserify example.js -g uglifyify -o bundle.js"
   },
@@ -12,6 +12,11 @@
   "license": "ISC",
   "devDependencies": {
     "beefy": "^2.1.5",
+    "chai": "^3.5.0",
+    "deep-freeze-strict": "^1.1.1",
+    "jsdom": "^8.1.0",
+    "mocha": "^2.4.5",
+    "mocha-jsdom": "^1.1.0",
     "uglifyify": "^3.0.1"
   },
   "browserify": {

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,8 @@
+if (typeof process === 'object') {
+  // Initialize node environment
+  global.expect = require('chai').expect
+  require('mocha-jsdom')()
+} else {
+  window.expect = window.chai.expect
+  window.require = function () { /* noop */ }
+}

--- a/test/unit/actions/set_selected_account_test.js
+++ b/test/unit/actions/set_selected_account_test.js
@@ -1,0 +1,26 @@
+var jsdom = require('mocha-jsdom')
+var assert = require('assert')
+var freeze = require('deep-freeze-strict')
+var path = require('path')
+
+var actions = require(path.join(__dirname, '..', '..', '..', 'app', 'actions.js'))
+var reducers = require(path.join(__dirname, '..', '..', '..', 'app', 'reducers.js'))
+
+describe('SET_SELECTED_ACCOUNT', function() {
+
+  it('sets the state.appState.activeAddress property of the state to the action.value', function() {
+    var initialState = {
+      activeAddress: 'foo',
+    }
+    freeze(initialState)
+
+    const action = {
+      type: actions.SET_SELECTED_ACCOUNT,
+      value: 'bar',
+    }
+    freeze(action)
+
+    var resultingState = reducers(initialState, action)
+    assert.equal(resultingState.appState.activeAddress, action.value)
+  });
+});


### PR DESCRIPTION
Added a single action unit test, the simplest possible kind of test in a react project.  Could be simplified further, but wanted to ensure some basic things in this first one.

The `test/setup.js` file is not used to its fullest extent here, but can be used to run the suite in a browser as well as node.js [as demonstrated here](https://github.com/rstacruz/mocha-jsdom/tree/master/examples/basic).

@kumavis 
