### PR TITLE
Vault generate/restore enhancements

### DIFF
--- a/app/actions.js
+++ b/app/actions.js
@@ -48,6 +48,7 @@ var actions = {
   showAccountDetail: showAccountDetail,
   showAccountsPage: showAccountsPage,
   showConfTxPage: showConfTxPage,
+  confirmSeedWords: confirmSeedWords,
   // config screen
   SHOW_CONFIG_PAGE: 'SHOW_CONFIG_PAGE',
   SET_RPC_TARGET: 'SET_RPC_TARGET',
@@ -55,6 +56,11 @@ var actions = {
   setRpcTarget: setRpcTarget,
   // hacky - need a way to get a reference to account manager
   _setAccountManager: _setAccountManager,
+  // loading overlay
+  SHOW_LOADING: 'SHOW_LOADING_INDICATION',
+  HIDE_LOADING: 'HIDE_LOADING_INDICATION',
+  showLoadingIndication: showLoadingIndication,
+  hideLoadingIndication: hideLoadingIndication,
 }
 
 module.exports = actions
@@ -80,10 +86,10 @@ function tryUnlockMetamask(password) {
   }
 }
 
-function createNewVault(password) {
+function createNewVault(password, entropy) {
   return (dispatch) => {
     dispatch(this.createNewVaultInProgress())
-    _accountManager.createNewVault(password, (err, result) => {
+    _accountManager.createNewVault(password, entropy, (err, result) => {
       dispatch(this.showNewVaultSeed(result))
     })
   }
@@ -92,8 +98,8 @@ function createNewVault(password) {
 function recoverFromSeed(password, seed) {
   return (dispatch) => {
     // dispatch(this.createNewVaultInProgress())
+    dispatch(this.unlockMetamask())
     _accountManager.recoverFromSeed(password, seed, (err, result) => {
-      dispatch(this.unlockMetamask())
       // dispatch(this.showNewVaultSeed(result))
     })
   }
@@ -224,6 +230,17 @@ function showAccountDetail(address) {
   }
 }
 
+function confirmSeedWords() {
+  return (dispatch) => {
+    dispatch(this.unlockMetamask())
+    dispatch(this.showLoadingIndication())
+    _accountManager.clearSeedWordCache((err) => {
+      console.log('Seed word cache cleared.')
+      dispatch(this.showAccountsPage())
+    })
+  }
+}
+
 function showAccountsPage() {
   return {
     type: this.SHOW_ACCOUNTS_PAGE,
@@ -263,5 +280,17 @@ function setRpcTarget(newRpc) {
   return {
     type: this.SET_RPC_TARGET,
     value: newRpc,
+  }
+}
+
+function showLoadingIndication() {
+  return {
+    type: this.SHOW_LOADING,
+  }
+}
+
+function hideLoadingIndication() {
+  return {
+    type: this.HIDE_LOADING,
   }
 }

--- a/app/actions.js
+++ b/app/actions.js
@@ -10,6 +10,8 @@ var actions = {
   SHOW_NEW_VAULT_SEED: 'SHOW_NEW_VAULT_SEED',
   SHOW_INFO_PAGE: 'SHOW_INFO_PAGE',
   RECOVER_FROM_SEED: 'RECOVER_FROM_SEED',
+  CLEAR_SEED_WORD_CACHE: 'CLEAR_SEED_WORD_CACHE',
+  clearSeedWordCache: clearSeedWordCache,
   recoverFromSeed: recoverFromSeed,
   unlockMetamask: unlockMetamask,
   showCreateVault: showCreateVault,
@@ -77,6 +79,7 @@ function tryUnlockMetamask(password) {
   return (dispatch) => {
     dispatch(this.unlockInProgress())
     _accountManager.submitPassword(password, (err) => {
+      dispatch(this.hideLoadingIndication())
       if (err) {
         dispatch(this.unlockFailed())
       } else {
@@ -217,9 +220,13 @@ function updateMetamaskState(newState) {
 }
 
 function lockMetamask() {
-  _accountManager.setLocked()
-  return {
-    type: this.LOCK_METAMASK,
+  return (dispatch) => {
+    _accountManager.setLocked((err) => {
+      dispatch({
+        type: this.LOCK_METAMASK,
+      })
+      dispatch(this.hideLoadingIndication())
+    })
   }
 }
 
@@ -230,13 +237,18 @@ function showAccountDetail(address) {
   }
 }
 
+function clearSeedWordCache() {
+  return {
+    type: this.CLEAR_SEED_WORD_CACHE
+  }
+}
+
 function confirmSeedWords() {
   return (dispatch) => {
     dispatch(this.showLoadingIndication())
     _accountManager.clearSeedWordCache((err) => {
+      dispatch(this.clearSeedWordCache())
       console.log('Seed word cache cleared.')
-      dispatch(this.hideLoadingIndication())
-      dispatch(this.lockMetamask())
     })
   }
 }

--- a/app/actions.js
+++ b/app/actions.js
@@ -232,11 +232,11 @@ function showAccountDetail(address) {
 
 function confirmSeedWords() {
   return (dispatch) => {
-    dispatch(this.unlockMetamask())
     dispatch(this.showLoadingIndication())
     _accountManager.clearSeedWordCache((err) => {
       console.log('Seed word cache cleared.')
-      dispatch(this.showAccountsPage())
+      dispatch(this.hideLoadingIndication())
+      dispatch(this.lockMetamask())
     })
   }
 }

--- a/app/app.js
+++ b/app/app.js
@@ -54,8 +54,6 @@ App.prototype.render = function() {
       shouldHaveFooter = false;
     case 'createVaultComplete':
       shouldHaveFooter = false;
-    case 'accounts':
-      break;
   }
 
   return (

--- a/app/app.js
+++ b/app/app.js
@@ -21,6 +21,7 @@ const ConfirmTxScreen = require('./conf-tx')
 // other views
 const ConfigScreen = require('./config')
 const InfoScreen = require('./info')
+const LoadingIndicator = require('./loading')
 
 module.exports = connect(mapStateToProps)(App)
 
@@ -36,6 +37,7 @@ function mapStateToProps(state) {
     currentView: state.appState.currentView,
     activeAddress: state.appState.activeAddress,
     transForward: state.appState.transForward,
+    seedWords: state.metamask.seedWords,
   }
 }
 
@@ -50,11 +52,17 @@ App.prototype.render = function() {
       shouldHaveFooter = false;
     case 'createVault':
       shouldHaveFooter = false;
+    case 'createVaultComplete':
+      shouldHaveFooter = false;
+    case 'accounts':
+      break;
   }
 
   return (
 
     h('.flex-column.flex-grow.full-height', [
+
+      h(LoadingIndicator),
 
       // top row
       h('.app-header.flex-column.flex-center', {
@@ -133,6 +141,13 @@ App.prototype.toggleMetamaskActive = function(){
 App.prototype.renderPrimary = function(state){
   var state = this.props
 
+  // If seed words haven't been dismissed yet, show them still.
+  /*
+  if (state.seedWords) {
+    return h(CreateVaultCompleteScreen, {key: 'createVaultComplete'})
+  }
+  */
+
   // show initialize screen
   if (!state.isInitialized) {
 
@@ -148,7 +163,7 @@ App.prototype.renderPrimary = function(state){
         return h(RestoreVaultScreen, {key: 'restoreVault'})
 
       default:
-        return h(InitializeMenuScreen, {key: 'createVaultComplete'})
+        return h(InitializeMenuScreen, {key: 'menuScreenInit'})
 
     }
   }

--- a/app/css/index.css
+++ b/app/css/index.css
@@ -127,7 +127,7 @@ app sections
   border-style: solid;
 }
 
-.initialize-screen input[type="password"] {
+.initialize-screen input[type="password"], .initialize-screen textarea {
   width: 300px;
   padding: 6px;
   border-radius: 6px;

--- a/app/css/transitions.css
+++ b/app/css/transitions.css
@@ -37,11 +37,11 @@
 
 /* loader transitions */
 .loader-enter, .loader-leave-active {
-  opacity: 0;
+  opacity: 0.0;
   transition: opacity 150 ease-in-out;
 }
 .loader-enter-active, .loader-leave {
-  opacity: 1;
+  opacity: 1.0;
   transition: opacity 150 ease-in-out;
 }
 

--- a/app/css/transitions.css
+++ b/app/css/transitions.css
@@ -35,3 +35,13 @@
   transition: transform 300ms ease-in-out;
 }
 
+/* loader transitions */
+.loader-enter, .loader-leave-active {
+  opacity: 0;
+  transition: opacity 150 ease-in-out;
+}
+.loader-enter-active, .loader-leave {
+  opacity: 1;
+  transition: opacity 150 ease-in-out;
+}
+

--- a/app/first-time/create-vault-complete.js
+++ b/app/first-time/create-vault-complete.js
@@ -15,11 +15,14 @@ function CreateVaultCompleteScreen() {
 function mapStateToProps(state) {
   return {
     seed: state.appState.currentView.context,
+    cachedSeed: state.metamask.seedWords,
   }
 }
 
 CreateVaultCompleteScreen.prototype.render = function() {
   var state = this.props
+  var seed = state.seed || state.cachedSeed
+
   return (
 
     h('.initialize-screen.flex-column.flex-center.flex-grow', [
@@ -29,17 +32,20 @@ CreateVaultCompleteScreen.prototype.render = function() {
         h('h2.page-subtitle', 'Vault Created'),
       ]),
 
-      h('h4.error', 'Important'),
-      h('.warning', 'These 12 words can restore all of your MetaMask accounts for this vault.\nSave them somewhere safe and secret!'),
+      h('span.error', { // Error for the right red
+        style: {
+          padding: '12px 20px 0px 20px',
+          textAlign: 'center',
+        }
+      }, 'These 12 words can restore all of your MetaMask accounts for this vault.\nSave them somewhere safe and secret.'),
 
-
-      h('h3', 'Wallet Seed'),
       h('textarea.twelve-word-phrase', {
         readOnly: true,
-      }, state.seed),
+        value: seed,
+      }),
 
       h('button.btn-thin', {
-        onClick: this.showAccounts.bind(this),
+        onClick: () => this.confirmSeedWords(),
       }, 'I\'ve copied it somewhere safe.'),
 
     ])
@@ -47,6 +53,7 @@ CreateVaultCompleteScreen.prototype.render = function() {
   )
 }
 
-CreateVaultCompleteScreen.prototype.showAccounts = function() {
-  this.props.dispatch(actions.showAccountsPage())
+CreateVaultCompleteScreen.prototype.confirmSeedWords = function() {
+  this.props.dispatch(actions.confirmSeedWords())
 }
+

--- a/app/first-time/create-vault-complete.js
+++ b/app/first-time/create-vault-complete.js
@@ -29,6 +29,9 @@ CreateVaultCompleteScreen.prototype.render = function() {
         h('h2.page-subtitle', 'Vault Created'),
       ]),
 
+      h('h4.error', 'Important'),
+      h('.warning', 'These 12 words can restore all of your MetaMask accounts for this vault.\nSave them somewhere safe and secret!'),
+
 
       h('h3', 'Wallet Seed'),
       h('textarea.twelve-word-phrase', {
@@ -38,9 +41,6 @@ CreateVaultCompleteScreen.prototype.render = function() {
       h('button.btn-thin', {
         onClick: this.showAccounts.bind(this),
       }, 'I\'ve copied it somewhere safe.'),
-
-      h('h4', 'Important'),
-      h('.warning', 'These 12 words can recreate all of your MetaMask accounts for this vault.\nKeep them private and save them!'),
 
     ])
 

--- a/app/first-time/create-vault.js
+++ b/app/first-time/create-vault.js
@@ -1,4 +1,5 @@
 const inherits = require('util').inherits
+
 const Component = require('react').Component
 const connect = require('react-redux').connect
 const h = require('react-hyperscript')
@@ -33,7 +34,7 @@ CreateVaultScreen.prototype.render = function() {
       // password
       h('label', {
         htmlFor: 'password-box',
-      }, 'New Password (min 8 chars):'),
+      }, 'Enter Password (min 8 chars):'),
 
       h('input', {
         type: 'password',
@@ -48,7 +49,18 @@ CreateVaultScreen.prototype.render = function() {
       h('input', {
         type: 'password',
         id: 'password-box-confirm',
-        onKeyPress: this.onMaybeCreate.bind(this),
+        onKeyPress: this.createVaultOnEnter.bind(this),
+      }),
+
+      // entropy
+      h('label', {
+        htmlFor: 'entropy-text-entry',
+      }, 'Enter random text (optional)'),
+
+      h('textarea', {
+        id: 'entropy-text-entry',
+        style: { resize: 'none' },
+        onKeyPress: this.createVaultOnEnter.bind(this),
       }),
 
       // submit
@@ -83,8 +95,9 @@ CreateVaultScreen.prototype.showInitializeMenu = function() {
 
 // create vault
 
-CreateVaultScreen.prototype.onMaybeCreate = function(event) {
+CreateVaultScreen.prototype.createVaultOnEnter = function(event) {
   if (event.key === 'Enter') {
+    event.preventDefault()
     this.createNewVault()
   }
 }
@@ -94,6 +107,8 @@ CreateVaultScreen.prototype.createNewVault = function(){
   var password = passwordBox.value
   var passwordConfirmBox = document.getElementById('password-box-confirm')
   var passwordConfirm = passwordConfirmBox.value
+  var entropy = document.getElementById('entropy-text-entry').value
+
   if (password.length < 8) {
     this.warning = 'password not long enough'
     return
@@ -102,5 +117,6 @@ CreateVaultScreen.prototype.createNewVault = function(){
     this.warning = 'passwords dont match'
     return
   }
-  this.props.dispatch(actions.createNewVault(password))
+
+  this.props.dispatch(actions.createNewVault(password, entropy))
 }

--- a/app/first-time/init-menu.js
+++ b/app/first-time/init-menu.js
@@ -7,6 +7,7 @@ const getCaretCoordinates = require('textarea-caret')
 const Mascot = require('../components/mascot')
 const actions = require('../actions')
 const CreateVaultScreen = require('./create-vault')
+const CreateVaultCompleteScreen = require('./create-vault-complete')
 
 module.exports = connect(mapStateToProps)(InitializeMenuScreen)
 
@@ -32,7 +33,7 @@ InitializeMenuScreen.prototype.render = function() {
       return h(CreateVaultScreen)
 
     case 'createVaultComplete':
-      return this.renderCreateVaultComplete()
+      return h(CreateVaultCompleteScreen)
 
     case 'restoreVault':
       return this.renderRestoreVault()
@@ -73,89 +74,6 @@ InitializeMenuScreen.prototype.renderMenu = function() {
       h('button.btn-thin', {
         onClick: this.showRestoreVault.bind(this),
       }, 'Restore Existing Vault'),
-
-    ])
-
-  )
-}
-
-InitializeMenuScreen.prototype.renderCreateVault = function() {
-  var state = this.props
-  return (
-
-    h('.initialize-screen.flex-column.flex-center.flex-grow', [
-
-      // subtitle and nav
-      h('.section-title.flex-row.flex-center', [
-        h('i.fa.fa-arrow-left.fa-lg.cursor-pointer', {
-          onClick: this.showInitializeMenu.bind(this),
-        }),
-        h('h2.page-subtitle', 'Create Vault'),
-      ]),
-
-      // password
-      h('label', {
-        htmlFor: 'password-box',
-      }, 'New Password (min 8 chars):'),
-
-      h('input', {
-        type: 'password',
-        id: 'password-box',
-        // onKeyPress: this.onKeyPress.bind(this),
-        // onInput: this.inputChanged.bind(this),
-      }),
-
-      // confirm password
-      h('label', {
-        htmlFor: 'password-box-confirm',
-      }, 'Confirm Password:'),
-
-      h('input', {
-        type: 'password',
-        id: 'password-box-confirm',
-        onKeyPress: this.onMaybeCreate.bind(this),
-        // onInput: this.inputChanged.bind(this),
-      }),
-
-      // submit
-      h('button.create-vault.btn-thin', {
-        onClick: this.createNewVault.bind(this),
-      }, 'OK'),
-
-      this.props.warning && (
-
-        h('span', this.props.warning)
-
-      ),
-
-    ])
-
-  )
-}
-
-InitializeMenuScreen.prototype.renderCreateVaultComplete = function() {
-  var state = this.props
-  return (
-
-    h('.initialize-screen.flex-column.flex-center.flex-grow', [
-
-      // subtitle and nav
-      h('.section-title.flex-row.flex-center', [
-        h('h2.page-subtitle', 'Vault Created'),
-      ]),
-
-
-      h('h3', 'Wallet Seed'),
-      h('textarea.twelve-word-phrase', {
-        value: 'hey ho what the actual hello rubber duck bumbersnatch crumplezone frankenfurter',
-      }),
-
-      h('button.btn-thin', {
-        onClick: this.showAccounts.bind(this),
-      }),
-
-      h('h4', 'Important'),
-      h('pre', 'These 12 words can recreate all of your MetaMask accounts for this vault.\nKeep them private and save them!'),
 
     ])
 
@@ -203,52 +121,3 @@ InitializeMenuScreen.prototype.showRestoreVault = function() {
   this.props.dispatch(actions.showRestoreVault())
 }
 
-InitializeMenuScreen.prototype.showAccounts = function() {
-  this.props.dispatch(actions.showAccountsPage())
-}
-
-// create vault
-
-InitializeMenuScreen.prototype.onMaybeCreate = function(event) {
-  if (event.key === 'Enter') {
-    this.createNewVault()
-  }
-}
-
-InitializeMenuScreen.prototype.createNewVault = function(){
-  var passwordBox = document.getElementById('password-box')
-  var password = passwordBox.value
-  var passwordConfirmBox = document.getElementById('password-box-confirm')
-  var passwordConfirm = passwordConfirmBox.value
-  if (password.length < 8) {
-    this.props.warning = 'password not long enough'
-    return
-  }
-  if (password !== passwordConfirm) {
-    this.props.warning = 'passwords dont match'
-    return
-  }
-  this.props.dispatch(actions.createNewVault(password))
-}
-
-InitializeMenuScreen.prototype.submitPassword = function(event){
-  var element = event.target
-  var password = element.value
-  element.value = ''
-  this.props.submitPassword(password)
-}
-
-InitializeMenuScreen.prototype.inputChanged = function(event){
-  // tell mascot to look at page action
-  var element = event.target
-  var boundingRect = element.getBoundingClientRect()
-  var coordinates = getCaretCoordinates(element, element.selectionEnd)
-  this.animationEventEmitter.emit('point', {
-    x: boundingRect.left + coordinates.left - element.scrollLeft,
-    y: boundingRect.top + coordinates.top - element.scrollTop,
-  })
-}
-
-InitializeMenuScreen.prototype.emitAnim = function(name, a, b, c){
-  this.animationEventEmitter.emit(name, a, b, c)
-}

--- a/app/first-time/restore-vault.js
+++ b/app/first-time/restore-vault.js
@@ -34,7 +34,7 @@ RestoreVaultScreen.prototype.render = function() {
       // wallet seed entry
       h('h3', 'Wallet Seed'),
       h('textarea.twelve-word-phrase', {
-        placeholder: 'hey ho what the actual hello rubber duck bumbersnatch crumplezone frankenfurter',
+        placeholder: 'Enter your secret twelve word phrase here to restore your vault.'
       }),
 
       // password

--- a/app/loading.js
+++ b/app/loading.js
@@ -1,0 +1,38 @@
+const inherits = require('util').inherits
+const Component = require('react').Component
+const h = require('react-hyperscript')
+const connect = require('react-redux').connect
+const actions = require('./actions')
+
+module.exports = connect(mapStateToProps)(LoadingIndicator)
+
+function mapStateToProps(state) {
+  return {
+    isLoading: state.appState.isLoading,
+  }
+}
+
+inherits(LoadingIndicator, Component)
+function LoadingIndicator() {
+  Component.call(this)
+}
+
+LoadingIndicator.prototype.render = function() {
+  console.dir(this.props)
+  var isLoading = this.props.isLoading
+
+  return (
+    h('div', {
+      style: {
+        position: 'absolute',
+        display: isLoading ? 'block' : 'none',
+        height: '100%',
+        width: '100%',
+        background: 'rgba(255, 255, 255, 0.5)',
+      }
+    }, [
+      'LOADING MOFO!'
+    ])
+  )
+}
+

--- a/app/loading.js
+++ b/app/loading.js
@@ -3,6 +3,7 @@ const Component = require('react').Component
 const h = require('react-hyperscript')
 const connect = require('react-redux').connect
 const actions = require('./actions')
+const ReactCSSTransitionGroup = require('react-addons-css-transition-group')
 
 module.exports = connect(mapStateToProps)(LoadingIndicator)
 
@@ -22,16 +23,28 @@ LoadingIndicator.prototype.render = function() {
   var isLoading = this.props.isLoading
 
   return (
-    h('div', {
-      style: {
-        position: 'absolute',
-        display: isLoading ? 'block' : 'none',
-        height: '100%',
-        width: '100%',
-        background: 'rgba(255, 255, 255, 0.5)',
-      }
+    h(ReactCSSTransitionGroup, {
+      transitionName: "loader",
+      transitionEnterTimeout: 150,
+      transitionLeaveTimeout: 150,
     }, [
-      'LOADING MOFO!'
+
+      isLoading ? h('div', {
+        style: {
+          position: 'absolute',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100%',
+          width: '100%',
+          background: 'rgba(255, 255, 255, 0.5)',
+        }
+      }, [
+        h('img', {
+          src: 'images/loading.svg',
+        }),
+      ]) : null,
+
     ])
   )
 }

--- a/app/reducers/app.js
+++ b/app/reducers/app.js
@@ -195,6 +195,15 @@ function reduceApp(state, action) {
       isLoading: false,
     })
 
+  case actions.CLEAR_SEED_WORD_CACHE:
+    return extend(appState, {
+      transForward: true,
+      currentView: {
+        name: 'accounts',
+      },
+      isLoading: false,
+    })
+
   default:
     return appState
 

--- a/app/reducers/app.js
+++ b/app/reducers/app.js
@@ -10,10 +10,17 @@ function reduceApp(state, action) {
     name: 'accounts',
   }
 
+  // confirm seed words
+  var seedConfView = {
+    name: 'createVaultComplete',
+  }
+  var seedWords = state.metamask.seedWords
+
   var appState = extend({
-    currentView: defaultView,
+    currentView: seedWords ? seedConfView : defaultView,
     currentDomain: 'example.com',
     transForward: true,
+    isLoading: false,
   }, state.appState)
 
   switch (action.type) {
@@ -65,6 +72,7 @@ function reduceApp(state, action) {
         inProgress: true,
       },
       transForward: true,
+      isLoading: true,
     })
 
   case actions.SHOW_NEW_VAULT_SEED:
@@ -74,6 +82,7 @@ function reduceApp(state, action) {
         context: action.value,
       },
       transForward: true,
+      isLoading: false,
     })
 
   // unlock
@@ -106,11 +115,13 @@ function reduceApp(state, action) {
     })
 
   case actions.SHOW_ACCOUNTS_PAGE:
+    var seedWords = state.metamask.seedWords
     return extend(appState, {
       currentView: {
-        name: 'accounts',
+        name: seedWords ? 'createVaultComplete' : 'accounts',
       },
       transForward: appState.currentView.name == 'locked',
+      isLoading: false,
     })
 
   case actions.SHOW_CONF_TX_PAGE:
@@ -172,6 +183,16 @@ function reduceApp(state, action) {
   case actions.UNLOCK_FAILED:
     return extend(appState, {
       passwordError: 'Incorrect password. Try again.'
+    })
+
+  case actions.SHOW_LOADING:
+    return extend(appState, {
+      isLoading: true,
+    })
+
+  case actions.HIDE_LOADING:
+    return extend(appState, {
+      isLoading: false,
     })
 
   default:

--- a/app/reducers/metamask.js
+++ b/app/reducers/metamask.js
@@ -17,6 +17,11 @@ function reduceMetamask(state, action) {
 
   switch (action.type) {
 
+  case actions.SHOW_ACCOUNTS_PAGE:
+    var state = extend(metamaskState)
+    delete state.seedWords
+    return state
+
   case actions.UPDATE_METAMASK_STATE:
     return extend(metamaskState, action.value)
 

--- a/app/reducers/metamask.js
+++ b/app/reducers/metamask.js
@@ -52,6 +52,13 @@ function reduceMetamask(state, action) {
     }
     return newState
 
+  case actions.CLEAR_SEED_WORD_CACHE:
+    var newState = extend(metamaskState, {
+      isInitialized: true,
+    })
+    delete newState.seedWords
+    return newState
+
   default:
     return metamaskState
 

--- a/app/template.js
+++ b/app/template.js
@@ -1,0 +1,31 @@
+const inherits = require('util').inherits
+const Component = require('react').Component
+const h = require('react-hyperscript')
+const connect = require('react-redux').connect
+const actions = require('./actions')
+
+module.exports = connect(mapStateToProps)(COMPONENTNAME)
+
+function mapStateToProps(state) {
+  return {}
+}
+
+inherits(COMPONENTNAME, Component)
+function COMPONENTNAME() {
+  Component.call(this)
+}
+
+COMPONENTNAME.prototype.render = function() {
+  var state = this.props
+  var rpc = state.rpc
+
+  return (
+    h('div', {
+      style: {
+        display: 'none',
+      }
+    }, [
+    ])
+  )
+}
+

--- a/test/unit/actions/tx_test.js
+++ b/test/unit/actions/tx_test.js
@@ -63,6 +63,8 @@ describe('tx confirmation screen', function() {
       describe('when there is an error', function() {
 
         before(function(done) {
+          alert = () => {/* noop */}
+
           actions._setAccountManager({
             approveTransaction(txId, cb) { cb('An error!') },
           })

--- a/test/unit/actions/tx_test.js
+++ b/test/unit/actions/tx_test.js
@@ -39,6 +39,7 @@ describe('tx confirmation screen', function() {
         actions._setAccountManager({
           approveTransaction(txId, cb) { cb('An error!') },
           cancelTransaction(txId) { /* noop */ },
+          clearSeedWordCache(cb) { cb() },
         })
 
         actions.cancelTx({id: firstTxId})(function(action) {


### PR DESCRIPTION
Did a lot more than I really wanted to in a single PR, but cleans up and enhances a LOT of the vault behavior.

First of all, the seed words shown to the user were accidentally hard coded.  We now show them actual seed words.

We now provide a field for the user to provide entropy when creating a new vault.

When a user is shown the seed words and clicks away, then clicks back in, the seed words were previously lost. We now persist them in the background process's localStorage, so we show the seed words to the user until they deliberately dismiss them.

We now have loading indication during vault creation, since it's a little slow.  This is captured in a global state value `state.appState.isLoading`, and can be triggered with the `action.showLoadingIndication()` and `actions.hideLoadingIndication()` actions.

We had two different seed word confirmation screen components, one was being shown when the vault was first created, one was shown when returning. There was a lot of duplicate code in the whole `app/first-time/init` file, so I deleted the cruft, unified the duplicates, and only left actually used code remaining.

Also simplified the seed word explanation, and put it at the top of the screen, so the user reads the explanation before the twelve random words, I think this should go a long way to making it more digestible.

This naturally has a `metamask-plugin` PR that has to be deployed at the same time.
