### PR TITLE
Fix Warning Text Indication

### DIFF
--- a/app/actions.js
+++ b/app/actions.js
@@ -14,6 +14,7 @@ var actions = {
   clearSeedWordCache: clearSeedWordCache,
   recoverFromSeed: recoverFromSeed,
   unlockMetamask: unlockMetamask,
+  unlockFailed: unlockFailed,
   showCreateVault: showCreateVault,
   showRestoreVault: showRestoreVault,
   showInitializeMenu: showInitializeMenu,
@@ -29,6 +30,9 @@ var actions = {
   tryUnlockMetamask: tryUnlockMetamask,
   lockMetamask: lockMetamask,
   unlockInProgress: unlockInProgress,
+  // error handling
+  displayWarning: displayWarning,
+  DISPLAY_WARNING: 'DISPLAY_WARNING',
   // accounts screen
   SET_SELECTED_ACCOUNT: 'SET_SELECTED_ACCOUNT',
   SHOW_ACCOUNT_DETAIL: 'SHOW_ACCOUNT_DETAIL',
@@ -306,5 +310,12 @@ function showLoadingIndication() {
 function hideLoadingIndication() {
   return {
     type: this.HIDE_LOADING,
+  }
+}
+
+function displayWarning(text) {
+  return {
+    type: this.DISPLAY_WARNING,
+    value: text,
   }
 }

--- a/app/first-time/create-vault.js
+++ b/app/first-time/create-vault.js
@@ -14,7 +14,9 @@ function CreateVaultScreen() {
 }
 
 function mapStateToProps(state) {
-  return {}
+  return {
+    warning: state.appState.warning,
+  }
 }
 
 CreateVaultScreen.prototype.render = function() {
@@ -68,20 +70,15 @@ CreateVaultScreen.prototype.render = function() {
         onClick: this.createNewVault.bind(this),
       }, 'OK'),
 
-      (!state.inProgress && this.warning) && (
-
-        h('span.in-progress-notification', this.warning)
+      (!state.inProgress && state.warning) && (
+        h('span.in-progress-notification', state.warning)
 
       ),
 
       state.inProgress && (
-
         h('span.in-progress-notification', 'Generating Seed...')
-
       ),
-
     ])
-
   )
 }
 
@@ -111,10 +108,12 @@ CreateVaultScreen.prototype.createNewVault = function(){
 
   if (password.length < 8) {
     this.warning = 'password not long enough'
+    this.props.dispatch(actions.displayWarning(this.warning))
     return
   }
   if (password !== passwordConfirm) {
     this.warning = 'passwords dont match'
+    this.props.dispatch(actions.displayWarning(this.warning))
     return
   }
 

--- a/app/first-time/restore-vault.js
+++ b/app/first-time/restore-vault.js
@@ -13,7 +13,9 @@ function RestoreVaultScreen() {
 }
 
 function mapStateToProps(state) {
-  return {}
+  return {
+    warning: state.appState.warning,
+  }
 }
 
 
@@ -58,10 +60,8 @@ RestoreVaultScreen.prototype.render = function() {
         onKeyPress: this.onMaybeCreate.bind(this),
       }),
 
-      (this.warning) && (
-
-        h('span.in-progress-notification', this.warning)
-
+      (state.warning) && (
+        h('span.error.in-progress-notification', state.warning)
       ),
 
       // submit
@@ -91,11 +91,14 @@ RestoreVaultScreen.prototype.restoreVault = function(){
   var passwordConfirmBox = document.getElementById('password-box-confirm')
   var passwordConfirm = passwordConfirmBox.value
   if (password.length < 8) {
-    this.warning = 'password not long enough'
+    this.warning = 'Password not long enough'
+
+    this.props.dispatch(actions.displayWarning(this.warning))
     return
   }
   if (password !== passwordConfirm) {
-    this.warning = 'passwords dont match'
+    this.warning = 'Passwords don\'t match'
+    this.props.dispatch(actions.displayWarning(this.warning))
     return
   }
   // check seed
@@ -103,9 +106,11 @@ RestoreVaultScreen.prototype.restoreVault = function(){
   var seed = seedBox.value
   if (seed.split(' ').length !== 12) {
     this.warning = 'passwords dont match'
+    this.props.dispatch(actions.displayWarning(this.warning))
     return
   }
   // submit
   this.warning = null
+  this.props.dispatch(actions.displayWarning(this.warning))
   this.props.dispatch(actions.recoverFromSeed(password, seed))
 }

--- a/app/reducers/app.js
+++ b/app/reducers/app.js
@@ -19,8 +19,9 @@ function reduceApp(state, action) {
   var appState = extend({
     currentView: seedWords ? seedConfView : defaultView,
     currentDomain: 'example.com',
-    transForward: true,
-    isLoading: false,
+    transForward: true, // Used to render transition direction
+    isLoading: false,   // Used to display loading indicator
+    warning: null,      // Used to display error text
   }, state.appState)
 
   switch (action.type) {
@@ -33,6 +34,7 @@ function reduceApp(state, action) {
         name: 'createVault',
       },
       transForward: true,
+      warning: null,
     })
 
   case actions.SHOW_RESTORE_VAULT:
@@ -91,11 +93,13 @@ function reduceApp(state, action) {
     return extend(appState, {
       currentView: defaultView,
       transForward: true,
+      warning: null,
     })
 
   case actions.LOCK_METAMASK:
     return extend(appState, {
       transForward: false,
+      warning: null,
     })
 
   // accounts
@@ -122,6 +126,7 @@ function reduceApp(state, action) {
       },
       transForward: appState.currentView.name == 'locked',
       isLoading: false,
+      warning: null,
     })
 
   case actions.SHOW_CONF_TX_PAGE:
@@ -131,6 +136,7 @@ function reduceApp(state, action) {
         context: 0,
       },
       transForward: true,
+      warning: null,
     })
 
   case actions.COMPLETED_TX:
@@ -141,7 +147,8 @@ function reduceApp(state, action) {
         currentView: {
           name: 'confTx',
           context: 0,
-        }
+        },
+        warning: null,
       })
     } else {
       return extend(appState, {
@@ -151,6 +158,7 @@ function reduceApp(state, action) {
           context: 0,
         },
         transForward: false,
+        warning: null,
       })
     }
 
@@ -159,7 +167,8 @@ function reduceApp(state, action) {
       transForward: true,
       currentView: {
         name: 'confTx',
-        context: ++appState.currentView.context
+        context: ++appState.currentView.context,
+        warning: null,
       }
     })
 
@@ -168,7 +177,8 @@ function reduceApp(state, action) {
       transForward: false,
       currentView: {
         name: 'confTx',
-        context: --appState.currentView.context
+        context: --appState.currentView.context,
+        warning: null,
       }
     })
 
@@ -177,12 +187,12 @@ function reduceApp(state, action) {
       currentView: {
         name: 'confTx',
         errorMessage: 'There was a problem submitting this transaction.',
-      }
+      },
     })
 
   case actions.UNLOCK_FAILED:
     return extend(appState, {
-      passwordError: 'Incorrect password. Try again.'
+      warning: 'Incorrect password. Try again.'
     })
 
   case actions.SHOW_LOADING:
@@ -202,6 +212,11 @@ function reduceApp(state, action) {
         name: 'accounts',
       },
       isLoading: false,
+    })
+
+  case actions.DISPLAY_WARNING:
+    return extend(appState, {
+      warning: action.value,
     })
 
   default:

--- a/app/unlock.js
+++ b/app/unlock.js
@@ -18,13 +18,13 @@ function UnlockScreen() {
 
 function mapStateToProps(state) {
   return {
-    errorMessage: state.appState.passwordError,
+    warning: state.appState.warning,
   }
 }
 
 UnlockScreen.prototype.render = function() {
   const state = this.props
-  const error = state.errorMessage
+  const warning = state.warning
   return (
 
     h('.unlock-screen.flex-column.flex-center.flex-grow', [
@@ -48,9 +48,9 @@ UnlockScreen.prototype.render = function() {
 
       h('.error', {
         style: {
-          display: error ? 'block' : 'none',
+          display: warning ? 'block' : 'none',
         }
-      }, error),
+      }, warning),
 
       h('button.primary.cursor-pointer', {
         onClick: this.onSubmit.bind(this),

--- a/test/unit/actions/warning_test.js
+++ b/test/unit/actions/warning_test.js
@@ -1,0 +1,24 @@
+var jsdom = require('mocha-jsdom')
+var assert = require('assert')
+var freeze = require('deep-freeze-strict')
+var path = require('path')
+
+var actions = require(path.join(__dirname, '..', '..', '..', 'app', 'actions.js'))
+var reducers = require(path.join(__dirname, '..', '..', '..', 'app', 'reducers.js'))
+
+describe('action DISPLAY_WARNING', function() {
+
+  it('sets appState.warning to provided value', function() {
+    var initialState = {
+      appState: {},
+    }
+    freeze(initialState)
+
+    const warningText = 'This is a sample warning message'
+
+    const action = actions.displayWarning(warningText)
+    const resultingState = reducers(initialState, action)
+
+    assert.equal(resultingState.appState.warning, warningText, 'warning text set')
+  });
+});


### PR DESCRIPTION
Warning text was coded into a variety of templates, but was not actually set using correct action/dispatcher/reducer patterns, so it was never actually being displayed.
- Added SHOW_WARNING action that sets the appState.warning property.
- Added appState.warning display to relevant templates.
- Cleared appState.warning on successful transition actions.

Fixes MetaMask/metamask-plugin#75
Helps  MetaMask/metamask-plugin#28
