### PR TITLE
Add Etherscan support

### DIFF
--- a/app/actions.js
+++ b/app/actions.js
@@ -58,6 +58,8 @@ var actions = {
   // config screen
   SHOW_CONFIG_PAGE: 'SHOW_CONFIG_PAGE',
   SET_RPC_TARGET: 'SET_RPC_TARGET',
+  USE_ETHERSCAN_PROVIDER: 'USE_ETHERSCAN_PROVIDER',
+  useEtherscanProvider: useEtherscanProvider,
   showConfigPage: showConfigPage,
   setRpcTarget: setRpcTarget,
   // hacky - need a way to get a reference to account manager
@@ -298,6 +300,13 @@ function setRpcTarget(newRpc) {
   return {
     type: this.SET_RPC_TARGET,
     value: newRpc,
+  }
+}
+
+function useEtherscanProvider() {
+  _accountManager.useEtherscanProvider()
+  return {
+    type: this.USE_ETHERSCAN_PROVIDER,
   }
 }
 

--- a/app/config.js
+++ b/app/config.js
@@ -9,6 +9,7 @@ module.exports = connect(mapStateToProps)(ConfigScreen)
 function mapStateToProps(state) {
   return {
     rpc: state.metamask.rpcTarget,
+    metamask: state.metamask,
   }
 }
 
@@ -21,6 +22,7 @@ function ConfigScreen() {
 ConfigScreen.prototype.render = function() {
   var state = this.props
   var rpc = state.rpc
+  var metamaskState = state.metamask
 
   return (
     h('.flex-column.flex-grow', [
@@ -43,10 +45,8 @@ ConfigScreen.prototype.render = function() {
           }
         }, [
 
-          h('div', [
-            h('h3', {style: { fontWeight: 'bold' }}, 'Current RPC'),
-            h('p', rpc)
-          ]),
+          currentProviderDisplay(metamaskState),
+
 
           h('div', [
             h('input', {
@@ -71,13 +71,42 @@ ConfigScreen.prototype.render = function() {
               },
               onClick(event) {
                 event.preventDefault()
+                state.dispatch(actions.useEtherscanProvider())
+              }
+            }, 'Use Main Network (experimental)')
+          ]),
+
+          h('div', [
+            h('button', {
+              style: {
+                alignSelf: 'center',
+              },
+              onClick(event) {
+                event.preventDefault()
                 state.dispatch(actions.setRpcTarget('https://rawtestrpc.metamask.io/'))
               }
-            }, 'Use Default (Test Network)')
-          ])
+            }, 'Use Morden Test Network')
+          ]),
+
         ]),
       ]),
     ])
   )
 }
 
+function currentProviderDisplay(metamaskState) {
+  console.log('metmam')
+  var type = metamaskState.provider.type
+
+  if (type === 'rpc') {
+    var rpc = metamaskState.rpcTarget
+    return h('div', [
+      h('h3', {style: { fontWeight: 'bold' }}, 'Currently using RPC'),
+      h('p', rpc)
+    ])
+  } else {
+    return h('div', [
+      h('h3', {style: { fontWeight: 'bold' }}, 'Currently using Main Network'),
+    ])
+  }
+}

--- a/app/css/index.css
+++ b/app/css/index.css
@@ -31,6 +31,13 @@ html, body {
 button {
   outline: none;
   cursor: pointer;
+  margin: 10px;
+  padding: 6px;
+  border: none;
+  border-radius: 3px;
+  background: #F7861C;
+  font-weight: 500;
+  color: white;
 }
 
 button.primary {


### PR DESCRIPTION
Added UI to allow the selection and display of our new Etherscan provider.

Requires MetaMask/metamask-plugin#82 to be merged in order for the new features to work.

Also applied orange button styles to all buttons, because boring buttons are boring.  We can refine them later.
