### PR TITLE
Fix error handling when restoring vault

### DIFF
--- a/app/actions.js
+++ b/app/actions.js
@@ -105,9 +105,15 @@ function createNewVault(password, entropy) {
 function recoverFromSeed(password, seed) {
   return (dispatch) => {
     // dispatch(this.createNewVaultInProgress())
-    dispatch(this.unlockMetamask())
     dispatch(this.showLoadingIndication())
     _accountManager.recoverFromSeed(password, seed, (err, result) => {
+      if (err) {
+        dispatch(this.hideLoadingIndication())
+        var message = err.message
+        return dispatch(this.displayWarning(err.message))
+      }
+
+      dispatch(this.unlockMetamask())
       dispatch(this.updateMetamaskState(result))
       dispatch(this.hideLoadingIndication())
     })

--- a/app/first-time/restore-vault.js
+++ b/app/first-time/restore-vault.js
@@ -103,9 +103,9 @@ RestoreVaultScreen.prototype.restoreVault = function(){
   }
   // check seed
   var seedBox = document.querySelector('textarea.twelve-word-phrase')
-  var seed = seedBox.value
+  var seed = seedBox.value.trim()
   if (seed.split(' ').length !== 12) {
-    this.warning = 'passwords dont match'
+    this.warning = 'seed phrases are 12 words long'
     this.props.dispatch(actions.displayWarning(this.warning))
     return
   }


### PR DESCRIPTION
Vault should indicate incorrect number of words correctly.
Errors from wallet should be displayed to the user.
