### PR TITLE
Set selected address on unlock

### DIFF
--- a/app/actions.js
+++ b/app/actions.js
@@ -90,6 +90,7 @@ function tryUnlockMetamask(password) {
         dispatch(this.unlockFailed())
       } else {
         dispatch(this.unlockMetamask())
+        dispatch(this.setSelectedAddress())
       }
     })
   }
@@ -116,6 +117,7 @@ function recoverFromSeed(password, seed) {
       }
 
       dispatch(this.unlockMetamask())
+      dispatch(this.setSelectedAddress())
       dispatch(this.updateMetamaskState(result))
       dispatch(this.hideLoadingIndication())
     })


### PR DESCRIPTION
When unlocking metamask, call setSelectedAddress on the idManager, so that it can select the first item.

Requires [this PR first](https://github.com/MetaMask/metamask-plugin/pull/89).
