### PR TITLE
Fix restored account experience

### DIFF
--- a/app/actions.js
+++ b/app/actions.js
@@ -126,6 +126,7 @@ function recoverFromSeed(password, seed) {
       dispatch(this.setSelectedAddress())
       dispatch(this.updateMetamaskState(result))
       dispatch(this.hideLoadingIndication())
+      dispatch(this.showAccountsPage())
     })
   }
 }

--- a/app/components/account-panel.js
+++ b/app/components/account-panel.js
@@ -63,7 +63,10 @@ AccountPanel.prototype.render = function() {
 }
 
 function balanceOrFaucetingIndication(account, isFauceting) {
-  if (isFauceting) {
+
+  // Temporarily deactivating isFauceting indication
+  // because it shows fauceting for empty restored accounts.
+  if (/*isFauceting*/ false) {
 
     return h('.flex-row.flex-space-between', [
       h('span.font-small', {


### PR DESCRIPTION
After restoring a vault, the bottom buttons were not shown (accounts page was not actually navigated to).

Also, if the first account was empty, it would indicate fauceting.  This is a bad experience for our `testrpc` users.
