### PR TITLE
Point mainnet at our rpc

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -83,7 +83,7 @@ ConfigScreen.prototype.render = function() {
               },
               onClick(event) {
                 event.preventDefault()
-                state.dispatch(actions.setRpcTarget('https://rawtestrpc.metamask.io/'))
+                state.dispatch(actions.setRpcTarget('https://testrpc.metamask.io/'))
               }
             }, 'Use Morden Test Network')
           ]),


### PR DESCRIPTION
When pressing main-net button, the provider now uses the normal RPC provider pointed at our production RPC instead of etherscan.
